### PR TITLE
fix: add inputs block

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -2,7 +2,10 @@
 name: actions-release-ui-components
 description: |
   Releases the UI Components package to NPM and GitHub.
-
+inputs:
+  NPM_TOKEN:
+    description: "The NPM token to use for publishing the package."
+    required: true
 runs:
   using: composite
   steps:


### PR DESCRIPTION
one of the consumer repos ran into a failure when using the action, i'm trying to rule out this missing inputs block

![image](https://github.com/PrefectHQ/actions-release-ui-components/assets/19556538/80561bdc-c929-4b34-9de6-4991db5fd16a)

https://github.com/PrefectHQ/prefect-ui-library/actions/runs/6725255883/job/18279237044