### PR TITLE
fix/Do not use git add for non root subdir usage

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -64,8 +64,7 @@ runs:
       working-directory: ${{ inputs.WORKING_DIR }}
       run: |
         git checkout -b $RELEASE_VERSION
-        git add *
-        git commit -m "$RELEASE_VERSION"
+        git commit -am "$RELEASE_VERSION"
         git push --set-upstream origin $RELEASE_VERSION
         gh pr create --base main -f
 


### PR DESCRIPTION
- Relates to: https://linear.app/prefect/issue/PLA-921/request-update-the-actions-release-ui-components-action-to-allow-for
- Git add will attempt to add files even though they are part of a .gitignore file which results in a run failures 🤷 